### PR TITLE
Add support for PKCS#8 encryption of private key data if the output f…

### DIFF
--- a/lib/cert.js
+++ b/lib/cert.js
@@ -150,7 +150,6 @@ function makeRaw(cert, type, keys, password) {
             var newPkcs12Der = forge.asn1.toDer(newPkcs12Asn1).getBytes();
             raw = newPkcs12Der;
         } else if (type === "pem") {
-            // TODO does this look okay? might need a \n
             if (!password || password === "") {
                 raw = forge.pki.privateKeyToPem(keys.privateKey);
             } else {

--- a/lib/cert.js
+++ b/lib/cert.js
@@ -151,8 +151,12 @@ function makeRaw(cert, type, keys, password) {
             raw = newPkcs12Der;
         } else if (type === "pem") {
             // TODO does this look okay? might need a \n
-            raw = forge.pki.privateKeyToPem(keys.privateKey) +
-                forge.pki.certificateToPem(cert);
+            if (!password || password === "") {
+                raw = forge.pki.privateKeyToPem(keys.privateKey);
+            } else {
+                raw = forge.pki.encryptRsaPrivateKey(keys.privateKey, password);
+            }           
+            raw = raw + "\n" + forge.pki.certificateToPem(cert);
         }
         
         if (raw) {

--- a/test/basic.js
+++ b/test/basic.js
@@ -76,7 +76,7 @@ describe("ineedatestcert.cert", function () {
         });
     });
     
-    it("should expose pem", function (done) {
+    it("should expose unencrypted pem", function (done) {
         this.timeout(1000*60);
         new Cert({
             b: 1024, // we use a smaller key size for tests
@@ -87,6 +87,24 @@ describe("ineedatestcert.cert", function () {
             var pemText = cert.getRaw();
             expect(pemText).toMatch(/BEGIN RSA PRIVATE KEY/);
             expect(pemText).toMatch(/END RSA PRIVATE KEY/);
+            expect(pemText).toMatch(/BEGIN CERTIFICATE/);
+            expect(pemText).toMatch(/END CERTIFICATE/);
+            done();
+        });
+    });
+    
+    it("should expose encrypted pem", function (done) {
+        this.timeout(1000*60);
+        new Cert({
+            b: 1024, // we use a smaller key size for tests
+            type: "pem",
+            password: "password"
+        }).crunch(function (err, cert) {
+            expect(err).toNotExist();
+            
+            var pemText = cert.getRaw();
+            expect(pemText).toMatch(/BEGIN ENCRYPTED PRIVATE KEY/);
+            expect(pemText).toMatch(/END ENCRYPTED PRIVATE KEY/);
             expect(pemText).toMatch(/BEGIN CERTIFICATE/);
             expect(pemText).toMatch(/END CERTIFICATE/);
             done();
@@ -118,6 +136,7 @@ describe("ineedatestcert.cert", function () {
             expect(err).toNotExist();
             
             var pemText = cert.getRawPublicOnly();
+            expect(pemText).toNotMatch(/PRIVATE KEY/);
             expect(pemText).toMatch(/BEGIN CERTIFICATE/);
             expect(pemText).toMatch(/END CERTIFICATE/);
             done();


### PR DESCRIPTION
#3 …ormat is PEM

If you're interested in supporting encrypted PEM instead of warning, I think this should do the trick.
